### PR TITLE
Fixed bug regarding size calculation of small S7 Structs

### DIFF
--- a/S7.Net/Types/Class.cs
+++ b/S7.Net/Types/Class.cs
@@ -99,6 +99,10 @@ namespace S7.Net.Types
                     numBytes = GetIncreasedNumberOfBytes(numBytes, property.PropertyType);
                 }
             }
+            // enlarge numBytes to next even number because S7-Structs in a DB always will be resized to an even byte count
+            numBytes = Math.Ceiling(numBytes);
+            if ((numBytes / 2 - Math.Floor(numBytes / 2.0)) > 0)
+                numBytes++;
             return (int)numBytes;
         }
 


### PR DESCRIPTION
There was an Error when you had Structs conaining less than 8 Bits. The size calculation in this case returned 0 and the Plc.ReadClass() method throwed an excpetion. Structs in Step7 within da DataBlock always starts with adresses that can by devided by two. The extended code ensures the correct size even if there are a couple of structs in a DataBlock containing only a few bits.